### PR TITLE
Test cluster pods health - flag all pods that are failed or pending

### DIFF
--- a/tests/cluster_sanity/test_cluster_sanity.py
+++ b/tests/cluster_sanity/test_cluster_sanity.py
@@ -1,11 +1,18 @@
 import pytest
+from ocp_resources.pod import Pod
 
 from utilities.infra import cluster_sanity
 
 
+@pytest.fixture(scope="session")
+def pods(admin_client):
+    return list(Pod.get(dyn_client=admin_client))
+
+
 @pytest.mark.smoke
-def test_cluster_sanity(nodes, junitxml_plugin):
+def test_cluster_sanity(nodes, pods, junitxml_plugin):
     cluster_sanity(
         nodes=nodes,
+        pods=pods,
         junitxml_property=junitxml_plugin,
     )

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1,8 +1,16 @@
 import logging
 
 from ocm_python_wrapper.ocm_client import OCMPythonClient
-from ocp_utilities.exceptions import NodeNotReadyError, NodeUnschedulableError
-from ocp_utilities.infra import assert_nodes_ready, assert_nodes_schedulable
+from ocp_utilities.exceptions import (
+    NodeNotReadyError,
+    NodeUnschedulableError,
+    PodsFailedOrPendingError,
+)
+from ocp_utilities.infra import (
+    assert_nodes_ready,
+    assert_nodes_schedulable,
+    assert_pods_failed_or_pending,
+)
 from pytest_testconfig import py_config
 
 from utilities.pytest_utils import exit_pytest_execution
@@ -13,6 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 def cluster_sanity(
     nodes,
+    pods,
     junitxml_property,
 ):
     """
@@ -30,8 +39,9 @@ def cluster_sanity(
         LOGGER.info("Check nodes sanity.")
         assert_nodes_ready(nodes=nodes)
         assert_nodes_schedulable(nodes=nodes)
+        assert_pods_failed_or_pending(pods=pods)
 
-    except (NodeNotReadyError, NodeUnschedulableError) as ex:
+    except (NodeNotReadyError, NodeUnschedulableError, PodsFailedOrPendingError) as ex:
         exit_pytest_execution(
             filename=exceptions_filename,
             message=ex.args[0],


### PR DESCRIPTION
Add cluster pods check test to test_cluster_sanity and flag all pods that are failed or pending with a warning.

```
[rhemming@unknown14857f717816 managed-services-integration-tests]$ pipenv run pytest tests/cluster_sanity/test_cluster_sanity.py --data-collector=data-collector.yaml
=================================================== test session starts ===================================================
platform linux -- Python 3.10.8, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/rhemming/git/managed-services-integration-tests, configfile: pytest.ini
plugins: testconfig-0.2.0, progress-1.2.2
collected 1 item                                                                                                          

tests/cluster_sanity/test_cluster_sanity.py 
--------------------------------------------------- test_cluster_sanity ---------------------------------------------------
---------------------------------------------------------- SETUP ----------------------------------------------------------
2023-01-11T20:19:18.229205 root ERROR load cache error: ResourceList.__init__() got an unexpected keyword argument 'base_resource_lookup'
---------------------------------------------------------- CALL ----------------------------------------------------------
2023-01-11T20:19:20.540894 utilities.infra INFO Running cluster sanity
2023-01-11T20:19:20.541112 utilities.infra INFO Check nodes sanity.
2023-01-11T20:19:20.541291 ocp_utilities.infra INFO Verify all nodes are ready.
2023-01-11T20:19:20.670208 ocp_utilities.infra INFO Verify all nodes are schedulable.
2023-01-11T20:19:20.812831 ocp_utilities.infra INFO Verify all pods are not failed nor pending.
----------------- 0 deselected, 0 passed, 0 skipped, 0 failed, 0 error, 0 xfail, 0 xpass, exit status 99  -----------------

================================================== 2 warnings in 17.31s ===================================================
! _pytest.outcomes.Exit: The following pods are failed or pending:
        ('installer-6-master-1.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed')
        ('installer-5-master-2.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed')
        ('installer-7-master-2.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed')
        ('installer-4-master-1.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed')
        ('installer-5-master-1.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed')
        ('installer-6-master-1.rhtestc2.lab.upshift.rdu2.redhat.com', 'Failed') !
```

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
