### PR TITLE
MSINTEROP-226: Verify nodes have no resource pressure (mem, CPU etc) or network issues

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -3,10 +3,12 @@ import logging
 from ocm_python_wrapper.ocm_client import OCMPythonClient
 from ocp_utilities.exceptions import (
     NodeNotReadyError,
+    NodesNotHealthyConditionError,
     NodeUnschedulableError,
     PodsFailedOrPendingError,
 )
 from ocp_utilities.infra import (
+    assert_nodes_in_healthy_condition,
     assert_nodes_ready,
     assert_nodes_schedulable,
     assert_pods_failed_or_pending,
@@ -27,9 +29,11 @@ def cluster_sanity(
     """
     Args:
         nodes (list): list of Node resources
+        pods (list): list of Pod resources
 
     Raises:
-        NodeNotReadyError or NodeUnschedulableError if node check failed
+        NodeNotReadyError, NodeUnschedulableError, PodsFailedOrPendingError, or
+        NodesNotHealthyConditionError if node check failed
     """
 
     exceptions_filename = "cluster_sanity_failure.txt"
@@ -39,9 +43,16 @@ def cluster_sanity(
         LOGGER.info("Check nodes sanity.")
         assert_nodes_ready(nodes=nodes)
         assert_nodes_schedulable(nodes=nodes)
+        assert_nodes_in_healthy_condition(nodes=nodes)
         assert_pods_failed_or_pending(pods=pods)
 
-    except (NodeNotReadyError, NodeUnschedulableError, PodsFailedOrPendingError) as ex:
+    except (
+        NodeNotReadyError,
+        NodeUnschedulableError,
+        PodsFailedOrPendingError,
+        NodesNotHealthyConditionError,
+    ) as ex:
+
         exit_pytest_execution(
             filename=exceptions_filename,
             message=ex.args[0],


### PR DESCRIPTION
Short description:
Verify nodes have no resource pressure (mem, CPU etc) or network issues. Implement as part of cluster sanity

More details:
Resources are consider under pressure if any of the following node conditions is True: DiskPressure. MemoryPressure, PIDPressure

https://www.datadoghq.com/blog/key-metrics-for-openshift-monitoring/#metric-to-alert-on-node-condition

What this PR does / why we need it:
Which issue(s) this PR fixes:
msinterop-226

Special notes for reviewer:
dependent on PR: https://github.com/RedHatQE/openshift-python-utilities/pull/113
Bug:

##### Bug:
