### PR TITLE
MSINTEROP-227, add test for cluster alerts using prometheus

### DIFF
--- a/tests/cluster_sanity/conftest.py
+++ b/tests/cluster_sanity/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ocp_utilities.monitoring import (
+    Prometheus
+)
+
+@pytest.fixture(scope="session")
+def prometheus():
+    return Prometheus()

--- a/tests/cluster_sanity/test_cluster_alerts.py
+++ b/tests/cluster_sanity/test_cluster_alerts.py
@@ -1,0 +1,27 @@
+import pytest
+import logging
+from tests.cluster_sanity.utils import verify_no_listed_alerts_on_cluster, verify_prometheus_connection
+
+TIMEOUT_3MIN = 3*60
+Alert_LIST=[
+    "KubePodNotReady",
+    "KubeNodeUnreachable",
+    "ClusterOperatorDown",
+]
+sample_query = 'sort_desc(sum(sum_over_time(ALERTS{alertstate="firing"}[24h])) by (alertname))'
+
+LOGGER = logging.getLogger(__name__)
+
+class TestClustrAlerts:
+    @pytest.mark.smoke
+    def test_no_alerts_firing_on_healthy_cluster(
+        self,prometheus,
+    ):
+      cluster_alerts_list = Alert_LIST.copy()
+      verify_no_listed_alerts_on_cluster(
+        prometheus=prometheus, alerts_list=cluster_alerts_list
+
+      )
+    @pytest.mark.smoke
+    def test_prometheus_query_response(self,prometheus):
+       verify_prometheus_connection(prometheus=prometheus,query=sample_query)

--- a/tests/cluster_sanity/utils.py
+++ b/tests/cluster_sanity/utils.py
@@ -1,0 +1,25 @@
+import logging
+
+TIMEOUT_3MIN = 3*60
+
+LOGGER = logging.getLogger(__name__)
+
+def verify_no_listed_alerts_on_cluster(prometheus, alerts_list):
+    """
+    It gets a list of alerts and verifies that none of them are firing on a cluster.
+    """
+    fired_alerts = {}
+    for alert in alerts_list:
+        
+        alert_state = prometheus.get_alert(alert=alert)
+        
+        if alert_state and alert_state[0]["metric"]["alertstate"] == "firing":
+            fired_alerts[alert] = alert_state
+    assert (
+        not fired_alerts
+    ), f"Alerts should not be fired on healthy cluster.\n {fired_alerts}"
+
+def verify_prometheus_connection(prometheus,query):
+    response = prometheus.query(query=query)
+    LOGGER.info(f'\n query response: \t {(response["data"]["result"])}')
+    assert response["status"] == "success"


### PR DESCRIPTION
added tests  to check the alerts from alert list are not firing since they are critical alerts and to test prometheus query response
test make use of monitoring module created here - 
https://github.com/RedHatQE/openshift-python-utilities/pull/134

